### PR TITLE
python-irclib use in IRC controller

### DIFF
--- a/giotto/controllers/irc_.py
+++ b/giotto/controllers/irc_.py
@@ -108,12 +108,17 @@ class IRCRequest(object):
         #print self.__repr__()
 
     def get_program_and_args(self, message, magic_token):
-        # channel invocation
+      if self.private_message == True:
+        program = message.split()[0]
+        args = message.split()[1:]
+      else:
+        # channel invocationa
         l = len(magic_token)
         parsed_message = message[l:]
         args = parsed_message.split()[1:]
         program = parsed_message.split()[0]
-        return program, args
+      
+      return program, args
 
     @property
     def looks_legit(self):
@@ -142,10 +147,10 @@ class IrcBot(irc.bot.SingleServerIRCBot):
     self.process_message(c, e)
 
   def on_pubmsg(self, c, e):
+    if e.arguments()[0].startswith(self.config['magic_token']) == False: return
     self.process_message(c, e)
  
   def process_message(self, c, e):
-    if e.arguments()[0].startswith(self.config['magic_token']) == False: return
 
     request = IRCRequest(e,self.config['magic_token'],c.get_nickname())
     if request.looks_legit == False: return

--- a/giotto/controllers/irc_.py
+++ b/giotto/controllers/irc_.py
@@ -19,16 +19,16 @@ parser.add_argument('--mock', action='store_true', help='Mock out the model')
 args = parser.parse_args()
 
 config = {
-    'host': 'chat.freenode.org',
+    'host': 'irc.synirc.net',
     'port': 6667,
-    'nick': 'giotto-bot',
+    'nick': 'test-bot',
     'ident': 'giotto',
     'realname': 'Giotto',
     'owner': '',
-    'channel': '#botwar',
+    'channel': '#atestthing',
     'magic_token': '!giotto ',
 }
-from giotto.controllers.irc import listen
+from giotto.controllers.irc_ import listen
 listen(programs, config, model_mock=args.mock)"""
 
 class IRCController(GiottoController):

--- a/giotto/giotto_project
+++ b/giotto/giotto_project
@@ -74,7 +74,7 @@ if args.http:
     os.chmod(filename, st.st_mode | stat.S_IEXEC)
 
 if args.irc:
-    from giotto.controllers.irc import irc_execution_snippet
+    from giotto.controllers.irc_ import irc_execution_snippet
     filename = 'giotto-irc'
     f = open(filename, 'w')
     f.write(template_controller + irc_execution_snippet)


### PR DESCRIPTION
Switches from the hardcoded irc implementation (didn't work if latency was high) to python-irclib from https://bitbucket.org/jaraco/irc

Requires module: irc

Renames irc.py to irc_.py due to unresolvable conflict with python-irclib and preference for loading irc.py from the local namespace.

Still buggy and has a lot of the same issues that the original IRC controller had, such as crashes when parse_kwargs is given strange arguments.
