### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-.. image:: https://pypip.in/v/giotto/badge.png
+.. image:: https://img.shields.io/pypi/v/giotto.svg
     :target: https://pypi.python.org/pypi/giotto
     
 .. image:: https://travis-ci.org/priestc/giotto.png?branch=master


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20giotto))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `giotto`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.